### PR TITLE
Refresh DoH stamps and minisign key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Quad9 Plain:
 # Minisign public key
 
 ```text
-RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN
+RWTp2E4t64BrL651lEiDLNon+DqzPG4jhZ97pfdNkcq1VDdocLKvl5FW
 ```
 

--- a/dnscrypt/quad9-resolvers-dnscrypt.md.minisig
+++ b/dnscrypt/quad9-resolvers-dnscrypt.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQBphd2+f6eiKsb7Yv28rim1aqHLM9j0G2Xxg/N2d9gJIECqoUft8fIKnlCboMn8Cof3ej8N281v0cfix+ntoEB/PHrM4Zahgc=
-trusted comment: timestamp:1627722505	file:quad9-resolvers-dnscrypt.md
-OFsFuEBpyAUKvwbrRkiRFLD/UvZblRr1oofi7pTjEF6ylzpXTPcMM1tkX3E39giI7kBQIiTnEK/GN5SHDOWTDA==
+RUTp2E4t64BrL1wBi5KazYp0rMar6FYKdpSbeQnzkG3M2a7SYNcEaZUPeigvw1QedCspnDjofuCEP7ni1Cr6rfoJJMQ9IZSRLwo=
+trusted comment: timestamp:1722967152	file:quad9-resolvers-dnscrypt.md	hashed
+/Mb8JWhnFdEmpjz0YaW80TbiHx446dMBhz3rg2+WVlJxpcCNOLR1dvoXAZHfwOf6bfG29eSNpL4ZQ4OWhKjxDg==

--- a/dnscrypt/quad9-resolvers-dnscrypt.toml
+++ b/dnscrypt/quad9-resolvers-dnscrypt.toml
@@ -1,6 +1,6 @@
 [sources.quad9-resolvers-dnscrypt]
 urls = ["https://quad9.net/dnscrypt/quad9-resolvers-dnscrypt.md", "https://raw.githubusercontent.com/Quad9DNS/dnscrypt-settings/main/dnscrypt/quad9-resolvers-dnscrypt.md"]
-minisign_key = "RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN"
+minisign_key = "RWTp2E4t64BrL651lEiDLNon+DqzPG4jhZ97pfdNkcq1VDdocLKvl5FW"
 cache_file = "quad9-resolvers-dnscrypt.md"
 refresh_delay = 72
 prefix = "quad9-"

--- a/dnscrypt/quad9-resolvers-doh.md
+++ b/dnscrypt/quad9-resolvers-doh.md
@@ -6,145 +6,145 @@ This is a list of all of the quad9 dns stamps available for filtered/unfiltered 
 
 ## doh-ip4-port443-filter-pri
 Quad9 (anycast) dnssec/no-log/filter 9.9.9.9
-sdns://AgMAAAAAAAAABzkuOS45LjkgKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoSZG5zOS5xdWFkOS5uZXQ6NDQzCi9kbnMtcXVlcnk
+sdns://AgMAAAAAAAAABzkuOS45LjkgsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8SZG5zOS5xdWFkOS5uZXQ6NDQzCi9kbnMtcXVlcnk
 
 ## doh-ip4-port5053-filter-pri
 Quad9 (anycast) dnssec/no-log/filter 9.9.9.9
-sdns://AgMAAAAAAAAABzkuOS45LjkgKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zOS5xdWFkOS5uZXQ6NTA1MwovZG5zLXF1ZXJ5
+sdns://AgMAAAAAAAAABzkuOS45LjkgsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zOS5xdWFkOS5uZXQ6NTA1MwovZG5zLXF1ZXJ5
 
 ## doh-ip4-port443-filter-alt
 Quad9 (anycast) dnssec/no-log/filter 149.112.112.9
-sdns://AgMAAAAAAAAADTE0OS4xMTIuMTEyLjkgKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoSZG5zOS5xdWFkOS5uZXQ6NDQzCi9kbnMtcXVlcnk
+sdns://AgMAAAAAAAAADTE0OS4xMTIuMTEyLjkgsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8SZG5zOS5xdWFkOS5uZXQ6NDQzCi9kbnMtcXVlcnk
 
 ## doh-ip4-port5053-filter-alt
 Quad9 (anycast) dnssec/no-log/filter 149.112.112.9
-sdns://AgMAAAAAAAAADTE0OS4xMTIuMTEyLjkgKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zOS5xdWFkOS5uZXQ6NTA1MwovZG5zLXF1ZXJ5
+sdns://AgMAAAAAAAAADTE0OS4xMTIuMTEyLjkgsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zOS5xdWFkOS5uZXQ6NTA1MwovZG5zLXF1ZXJ5
 
 ## doh-ip4-port443-filter-alt2
 Quad9 (anycast) dnssec/no-log/filter 149.112.112.112
-sdns://AgMAAAAAAAAADzE0OS4xMTIuMTEyLjExMiAqFfXWrLbnwJAa3k67x0OyzNSJAytG4WQvBpNoMAElihFkbnMucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgMAAAAAAAAADzE0OS4xMTIuMTEyLjExMiCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxFkbnMucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
 ## doh-ip4-port5053-filter-alt2
 Quad9 (anycast) dnssec/no-log/filter 149.112.112.112
-sdns://AgMAAAAAAAAADzE0OS4xMTIuMTEyLjExMiAqFfXWrLbnwJAa3k67x0OyzNSJAytG4WQvBpNoMAElihJkbnMucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAADzE0OS4xMTIuMTEyLjExMiCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxJkbnMucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
 ## doh-ip6-port443-filter-pri
 Quad9 (anycast) dnssec/no-log/filter 2620:fe::fe
-sdns://AgMAAAAAAAAADVsyNjIwOmZlOjpmZV0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoRZG5zLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAADVsyNjIwOmZlOjpmZV0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8RZG5zLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip6-port5053-filter-pri
 Quad9 (anycast) dnssec/no-log/filter 2620:fe::fe
-sdns://AgMAAAAAAAAADVsyNjIwOmZlOjpmZV0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoSZG5zLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgMAAAAAAAAADVsyNjIwOmZlOjpmZV0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8SZG5zLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip6-port443-filter-alt
 Quad9 (anycast) dnssec/no-log/filter 2620:fe::9
-sdns://AgMAAAAAAAAADFsyNjIwOmZlOjo5XSAqFfXWrLbnwJAa3k67x0OyzNSJAytG4WQvBpNoMAElihFkbnMucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgMAAAAAAAAADFsyNjIwOmZlOjo5XSCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxFkbnMucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
 ## doh-ip6-port5053-filter-alt
 Quad9 (anycast) dnssec/no-log/filter 2620:fe::9
-sdns://AgMAAAAAAAAADFsyNjIwOmZlOjo5XSAqFfXWrLbnwJAa3k67x0OyzNSJAytG4WQvBpNoMAElihJkbnMucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAADFsyNjIwOmZlOjo5XSCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxJkbnMucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
 ## doh-ip6-port443-filter-alt2
 Quad9 (anycast) dnssec/no-log/filter 2620:fe::fe:9
-sdns://AgMAAAAAAAAAD1syNjIwOmZlOjpmZTo5XSAqFfXWrLbnwJAa3k67x0OyzNSJAytG4WQvBpNoMAElihJkbnM5LnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAAD1syNjIwOmZlOjpmZTo5XSCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxJkbnM5LnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip6-port5053-filter-alt2
 Quad9 (anycast) dnssec/no-log/filter 2620:fe::fe:9
-sdns://AgMAAAAAAAAAD1syNjIwOmZlOjpmZTo5XSAqFfXWrLbnwJAa3k67x0OyzNSJAytG4WQvBpNoMAElihNkbnM5LnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgMAAAAAAAAAD1syNjIwOmZlOjpmZTo5XSCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxNkbnM5LnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip4-port443-nofilter-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter 9.9.9.10
-sdns://AgYAAAAAAAAACDkuOS45LjEwICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKE2RuczEwLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAACDkuOS45LjEwILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvE2RuczEwLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port5053-nofilter-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter 9.9.9.10
-sdns://AgYAAAAAAAAACDkuOS45LjEwICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKFGRuczEwLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgYAAAAAAAAACDkuOS45LjEwILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvFGRuczEwLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip4-port443-nofilter-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter 149.112.112.10
-sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEwICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKE2RuczEwLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEwILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvE2RuczEwLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port5053-nofilter-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter 149.112.112.10
-sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEwICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKFGRuczEwLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEwILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvFGRuczEwLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip6-port443-nofilter-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter 2620:fe::10
-sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMF0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zMTAucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMF0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zMTAucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
 ## doh-ip6-port5053-nofilter-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter 2620:fe::10
-sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMF0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoUZG5zMTAucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMF0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8UZG5zMTAucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
 ## doh-ip6-port443-nofilter-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter 2620:fe::fe:10
-sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMF0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zMTAucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMF0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zMTAucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
 ## doh-ip6-port5053-nofilter-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter 2620:fe::fe:10
-sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMF0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoUZG5zMTAucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMF0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8UZG5zMTAucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port443-filter-ecs-pri
 Quad9 (anycast) dnssec/no-log/filter/ecs 9.9.9.11
-sdns://AgMAAAAAAAAACDkuOS45LjExICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKE2RuczExLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAACDkuOS45LjExILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvE2RuczExLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port5053-filter-ecs-pri
 Quad9 (anycast) dnssec/no-log/filter/ecs 9.9.9.11
-sdns://AgMAAAAAAAAACDkuOS45LjExICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKFGRuczExLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgMAAAAAAAAACDkuOS45LjExILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvFGRuczExLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip4-port443-filter-ecs-alt
 Quad9 (anycast) dnssec/no-log/filter/ecs 149.112.112.11
-sdns://AgMAAAAAAAAADjE0OS4xMTIuMTEyLjExICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKE2RuczExLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAADjE0OS4xMTIuMTEyLjExILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvE2RuczExLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port5053-filter-ecs-alt
 Quad9 (anycast) dnssec/no-log/filter/ecs 149.112.112.11
-sdns://AgMAAAAAAAAADjE0OS4xMTIuMTEyLjExICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKFGRuczExLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgMAAAAAAAAADjE0OS4xMTIuMTEyLjExILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvFGRuczExLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip6-port443-filter-ecs-pri
 Quad9 (anycast) dnssec/no-log/filter/ecs 2620:fe::11
-sdns://AgMAAAAAAAAADVsyNjIwOmZlOjoxMV0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zMTEucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgMAAAAAAAAADVsyNjIwOmZlOjoxMV0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zMTEucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
 ## doh-ip6-port5053-filter-ecs-pri
 Quad9 (anycast) dnssec/no-log/filter/ecs 2620:fe::11
-sdns://AgMAAAAAAAAADVsyNjIwOmZlOjoxMV0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoUZG5zMTEucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAADVsyNjIwOmZlOjoxMV0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8UZG5zMTEucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
 ## doh-ip6-port443-filter-ecs-alt
 Quad9 (anycast) dnssec/no-log/filter/ecs 2620:fe::fe:11
-sdns://AgMAAAAAAAAAEFsyNjIwOmZlOjpmZToxMV0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zMTEucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgMAAAAAAAAAEFsyNjIwOmZlOjpmZToxMV0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zMTEucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
 ## doh-ip6-port5053-filter-ecs-alt
 Quad9 (anycast) dnssec/no-log/filter/ecs 2620:fe::fe:11
-sdns://AgMAAAAAAAAAEFsyNjIwOmZlOjpmZToxMV0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoUZG5zMTEucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAAEFsyNjIwOmZlOjpmZToxMV0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8UZG5zMTEucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port443-nofilter-ecs-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 9.9.9.12
-sdns://AgYAAAAAAAAACDkuOS45LjEyICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKE2RuczEyLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAACDkuOS45LjEyILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvE2RuczEyLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port5053-nofilter-ecs-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 9.9.9.12
-sdns://AgYAAAAAAAAACDkuOS45LjEyICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKFGRuczEyLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgYAAAAAAAAACDkuOS45LjEyILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvFGRuczEyLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip4-port443-nofilter-ecs-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 149.112.112.12
-sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEyICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKE2RuczEyLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEyILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvE2RuczEyLnF1YWQ5Lm5ldDo0NDMKL2Rucy1xdWVyeQ
 
 ## doh-ip4-port5053-nofilter-ecs-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 149.112.112.12
-sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEyICoV9dastufAkBreTrvHQ7LM1IkDK0bhZC8Gk2gwASWKFGRuczEyLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
+sdns://AgYAAAAAAAAADjE0OS4xMTIuMTEyLjEyILAZIHRLu3bJqwU-AeB7fgUORz0g95976kNfr-Q8nSQvFGRuczEyLnF1YWQ5Lm5ldDo1MDUzCi9kbnMtcXVlcnk
 
 ## doh-ip6-port443-nofilter-ecs-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 2620:fe::12
-sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMl0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zMTIucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMl0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zMTIucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
 ## doh-ip6-port5053-nofilter-ecs-pri
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 2620:fe::12
-sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMl0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoUZG5zMTIucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMl0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8UZG5zMTIucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
-## doh-ip6-port443-nofilter-ecs-alt 
+## doh-ip6-port443-nofilter-ecs-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 2620:fe::fe:12
-sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMl0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoTZG5zMTIucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
+sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMl0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8TZG5zMTIucXVhZDkubmV0OjQ0MwovZG5zLXF1ZXJ5
 
-## doh-ip6-port5053-nofilter-ecs-alt 
+## doh-ip6-port5053-nofilter-ecs-alt
 Quad9 (anycast) no-dnssec/no-log/no-filter/ecs 2620:fe::fe:12
-sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMl0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoUZG5zMTIucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMl0gsBkgdEu7dsmrBT4B4Ht-BQ5HPSD3n3vqQ1-v5DydJC8UZG5zMTIucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 

--- a/dnscrypt/quad9-resolvers-doh.md.minisig
+++ b/dnscrypt/quad9-resolvers-doh.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQBphd2+f6eiPoV6f/3n5LCba4xIA9BPY7g8h5O3HnpeiwSUo7aE5FNjVsnm7hVVh/WqiOYNX1ZDlAQSuUn76JTZJs1uRg2vQM=
-trusted comment: timestamp:1627722501	file:quad9-resolvers-doh.md
-aJ3eONlg2kODAqkdpK0AsPQNr3RXkQtUhas1njyUtk2ooY/2CNVRcT9n6w6TvdZMp+CZDXBfGayEI14LkGXhBw==
+RUTp2E4t64BrL7WSETYr3pt8eaBBYirMUjmbY6aGNdBr/CU52Enwq7GH1R+tWZgLd9yb6QSj0gp+Z6+rQnb9ulPsx4/4D5fdLAE=
+trusted comment: timestamp:1722967216	file:quad9-resolvers-doh.md	hashed
+JiFhBOUenwBe86nzUdbTUTugXDRhLpKvYbY/VmyiIVlHxe3RKUAC+xzinPuOdqp3SphuJYXeBX0jIRKAKBiiDA==

--- a/dnscrypt/quad9-resolvers-doh.toml
+++ b/dnscrypt/quad9-resolvers-doh.toml
@@ -1,6 +1,6 @@
 [sources.quad9-resolvers-doh]
 urls = ["https://quad9.net/dnscrypt/quad9-resolvers-doh.md", "https://raw.githubusercontent.com/Quad9DNS/dnscrypt-settings/main/dnscrypt/quad9-resolvers-doh.md"]
-minisign_key = "RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN"
+minisign_key = "RWTp2E4t64BrL651lEiDLNon+DqzPG4jhZ97pfdNkcq1VDdocLKvl5FW"
 cache_file = "quad9-resolvers-doh.md"
 refresh_delay = 72
 prefix = "quad9-"

--- a/dnscrypt/quad9-resolvers-dot.md.minisig
+++ b/dnscrypt/quad9-resolvers-dot.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQBphd2+f6eiOJnKGK58P899ijxNjKgi53Q3Ou08V73ew+4GcGVXvmcnAqei2tDyKS3P54K058mDujLF3cZu76GltXOUWsGrwo=
-trusted comment: timestamp:1627722509	file:quad9-resolvers-dot.md
-daDUloBZE4BYpo0AyjvV0uPBkP6HTxYCHDHMBztXsC3WoLecFUF6dPhP0TFEwALGSNbnaFFQDJixXGAeZFzIAw==
+RUTp2E4t64BrLyOlfhp06AcinbSfSdm5IfQJ6LLxorsFs34cEhPhvecrlSVb15da0ue1+ll2zpuVvL93mQzYnT1YiByeF71G4Ao=
+trusted comment: timestamp:1722967224	file:quad9-resolvers-dot.md	hashed
+7wIIAcl3V9wQ8Ko4WMo9sErawr8CWG4sFOvJENit6vRj4prTUk5gbgeG/tDFpUg4E4ylQsF1uBHDx0XMXTsvBA==

--- a/dnscrypt/quad9-resolvers-dot.toml
+++ b/dnscrypt/quad9-resolvers-dot.toml
@@ -1,6 +1,6 @@
 [sources.quad9-resolvers-dot]
 urls = ["https://quad9.net/dnscrypt/quad9-resolvers-dot.md", "https://raw.githubusercontent.com/Quad9DNS/dnscrypt-settings/main/dnscrypt/quad9-resolvers-dot.md"]
-minisign_key = "RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN"
+minisign_key = "RWTp2E4t64BrL651lEiDLNon+DqzPG4jhZ97pfdNkcq1VDdocLKvl5FW"
 cache_file = "quad9-resolvers-dot.md"
 refresh_delay = 72
 prefix = "quad9-"

--- a/dnscrypt/quad9-resolvers-plain.md.minisig
+++ b/dnscrypt/quad9-resolvers-plain.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQBphd2+f6eiHVfCj9F3SEgAhRNBtl4//Tddqepvb7YMbCewhVrw6N/s/XTWIYe+dbbq9GnrJMQX5INCqOviHfz1/w97ZyCiQw=
-trusted comment: timestamp:1627722513	file:quad9-resolvers-plain.md
-D+E5ALNuaoTsMVugkPELDtlR2L75ATY4z42Bv9Y11mMC//wEQVl7c0RYSf8KmvuLRTeCRKT6Qu6dqgiU5UG3Aw==
+RUTp2E4t64BrL6JZeggqn1+QxJcRWQNhyw8RQPsyWfD6NtcIU2/FhlQiOlKjnK2KEfHhM0pF9l05ToWILgXjA0/0vQusQLvNhQg=
+trusted comment: timestamp:1722967232	file:quad9-resolvers-plain.md	hashed
+Xeyn8pJi5+nGQ5KhY/VtNvJwv22feJ/c5UIej2GZHKfU8eCQsDduZiryxWZTvFAwvOQzXh9qTCb4mNkZ9SfACQ==

--- a/dnscrypt/quad9-resolvers-plain.toml
+++ b/dnscrypt/quad9-resolvers-plain.toml
@@ -1,6 +1,6 @@
 [sources.quad9-resolvers-plain]
 urls = ["https://quad9.net/dnscrypt/quad9-resolvers-plain.md", "https://raw.githubusercontent.com/Quad9DNS/dnscrypt-settings/main/dnscrypt/quad9-resolvers-plain.md"]
-minisign_key = "RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN"
+minisign_key = "RWTp2E4t64BrL651lEiDLNon+DqzPG4jhZ97pfdNkcq1VDdocLKvl5FW"
 cache_file = "quad9-resolvers-plain.md"
 refresh_delay = 72
 prefix = "quad9-"

--- a/dnscrypt/quad9-resolvers.md
+++ b/dnscrypt/quad9-resolvers.md
@@ -12,7 +12,7 @@ To use this list, add this to the `[sources]` section of your `dnscrypt-proxy.to
 
     [sources.quad9-resolvers]
     urls = ["https://quad9.net/dnscrypt/quad9-resolvers.md", "https://raw.githubusercontent.com/Quad9DNS/dnscrypt-settings/main/dnscrypt/quad9-resolvers.md"]
-    minisign_key = "RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN"
+    minisign_key = "RWTp2E4t64BrL651lEiDLNon+DqzPG4jhZ97pfdNkcq1VDdocLKvl5FW"
     cache_file = "quad9-resolvers.md"
     refresh_delay = 72
     prefix = "quad9-"

--- a/dnscrypt/quad9-resolvers.md.minisig
+++ b/dnscrypt/quad9-resolvers.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQBphd2+f6eiCU+/Ha8FpTizQU8G0IPnbhSHrhSXizaYbRH/mtmzgCyxkMMDvgxcSmzZ6/j2cz7LO3SIueDB2zL7oelTUosIgI=
-trusted comment: timestamp:1627722498	file:quad9-resolvers.md
-zwppZSyYb2N5jUqosF22PomqGi6ebg42mwwA4H9xjiHMb/8JD9wd3CEWChvAylb/Dl6Ui58L9Q9Hmu36xToSDA==
+RUTp2E4t64BrLx7D5VgUpzd5m4WYzZbmW8sFgmWJbHKj3JAmACrE1A5CCk9oFZWXNrw8pg3nlPZ14/0uBjBr2+0+XRicDHanuAQ=
+trusted comment: timestamp:1722967239	file:quad9-resolvers.md	hashed
+IYdnCdC9ufOjFVCGzBwLlzga74R5jwJhSb4wumaMQk1aEU8QpJCxDxCv5DAM0ikug5h9aQQm7yeTFMbDUGyVDA==

--- a/dnscrypt/quad9-resolvers.toml
+++ b/dnscrypt/quad9-resolvers.toml
@@ -1,6 +1,6 @@
 [sources.quad9-resolvers]
 urls = ["https://quad9.net/dnscrypt/quad9-resolvers.md", "https://raw.githubusercontent.com/Quad9DNS/dnscrypt-settings/main/dnscrypt/quad9-resolvers.md"]
-minisign_key = "RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN"
+minisign_key = "RWTp2E4t64BrL651lEiDLNon+DqzPG4jhZ97pfdNkcq1VDdocLKvl5FW"
 cache_file = "quad9-resolvers.md"
 refresh_delay = 72
 prefix = "quad9-"


### PR DESCRIPTION
Quad9 had updated the TLS certificate which is now signed by a new intermediary. Since the fingerprint for the certificate has changed, we need to update the stamps to reflect the change.
While at it, we also rotated the minisign key and signed all the files using the new key.