### PR TITLE
Update signature using legacy algorithm (Fixes #8)

### DIFF
--- a/dnscrypt/quad9-resolvers-dnscrypt.md.minisig
+++ b/dnscrypt/quad9-resolvers-dnscrypt.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RUTp2E4t64BrL1wBi5KazYp0rMar6FYKdpSbeQnzkG3M2a7SYNcEaZUPeigvw1QedCspnDjofuCEP7ni1Cr6rfoJJMQ9IZSRLwo=
-trusted comment: timestamp:1722967152	file:quad9-resolvers-dnscrypt.md	hashed
-/Mb8JWhnFdEmpjz0YaW80TbiHx446dMBhz3rg2+WVlJxpcCNOLR1dvoXAZHfwOf6bfG29eSNpL4ZQ4OWhKjxDg==
+RWTp2E4t64BrL8zPKyZMKeqfHtEUZyJ6F9gRGjN9tSPiD7bY41WoKTTJqDLNMgDAxIi8RBuS8hBJFTJH4qvA5unBzQtXDUXRvgE=
+trusted comment: timestamp:1723206106	file:quad9-resolvers-dnscrypt.md
+6TDGZE4V3BcYdv5SPL/EXF/iC1n/iSWvRpjbf1mAl69G/Z/1qMoQbHY++6X3Ro847TMvKH5iw8HvKU1B0fYtCQ==

--- a/dnscrypt/quad9-resolvers-doh.md.minisig
+++ b/dnscrypt/quad9-resolvers-doh.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RUTp2E4t64BrL7WSETYr3pt8eaBBYirMUjmbY6aGNdBr/CU52Enwq7GH1R+tWZgLd9yb6QSj0gp+Z6+rQnb9ulPsx4/4D5fdLAE=
-trusted comment: timestamp:1722967216	file:quad9-resolvers-doh.md	hashed
-JiFhBOUenwBe86nzUdbTUTugXDRhLpKvYbY/VmyiIVlHxe3RKUAC+xzinPuOdqp3SphuJYXeBX0jIRKAKBiiDA==
+RWTp2E4t64BrLz7RSiG3QrktuNYpBc+v8ajB/0paSpgjUCVnZDXU0lxu9CKy3k2FipXFOWcCFqUXEDULyfB3OeyaPogHUdDsoQo=
+trusted comment: timestamp:1723206106	file:quad9-resolvers-doh.md
+wJ4PS7NEAT9ra6HulbuVwLSXn8TbOjWXAvrlrZrufEjXDOIqNoFCs5W6abrQlnV6KBLkSv2rov4QbUZxtDjlAA==

--- a/dnscrypt/quad9-resolvers-dot.md.minisig
+++ b/dnscrypt/quad9-resolvers-dot.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RUTp2E4t64BrL3jfgNdbBIkzUHuRN6YPgHdZv8LLvlYurnEZko9/f/4V6S5jpxuTZ4FmdRJTQlFAJkFqQAa4qDKZThZa9NrwcAU=
-trusted comment: timestamp:1723059522	file:quad9-resolvers-dot.md	hashed
-jz7Wl8+E2prVYgjHm6grbFS3rMOYz5z+ZsfgsgDayxfkFGcT6nANr1RKzDtHy5lakac/9fz9QnRBxmefmX0PBw==
+RWTp2E4t64BrL3j2D+KxfbpRwCbRBOGWzJT2A9K5GHavbHMOJVX1Ayz05/2F/LxbYNkBVdyyVpKFsIx7SZ1Z2I24JKgEUqmE3AQ=
+trusted comment: timestamp:1723206106	file:quad9-resolvers-dot.md
+D9Ld88GmnYH3XlNmFbwAdAtrnFGAhOcuKNwD5h5Vf4BL7wufS6S8TSr8TaRPOFtVTqUv99IaEa4gdgzmM8G5Bg==

--- a/dnscrypt/quad9-resolvers-plain.md.minisig
+++ b/dnscrypt/quad9-resolvers-plain.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RUTp2E4t64BrL6JZeggqn1+QxJcRWQNhyw8RQPsyWfD6NtcIU2/FhlQiOlKjnK2KEfHhM0pF9l05ToWILgXjA0/0vQusQLvNhQg=
-trusted comment: timestamp:1722967232	file:quad9-resolvers-plain.md	hashed
-Xeyn8pJi5+nGQ5KhY/VtNvJwv22feJ/c5UIej2GZHKfU8eCQsDduZiryxWZTvFAwvOQzXh9qTCb4mNkZ9SfACQ==
+RWTp2E4t64BrL+SoBCN+vOSCSwND/lIUuPSx+ytTIgliBcCAvUPzxMG8jSu1c8rI4dtyOcnuLd05xgQGV8VdS0ds3NFNOiJVPwQ=
+trusted comment: timestamp:1723206106	file:quad9-resolvers-plain.md
+btKBUApSnEBRGSZJG6yhAVGdDmm0OKusg2vAU9uJp0KFElCl99/pwR2OzZxiDSErdvxKOrwe3GsfWv1o6G8mBg==

--- a/dnscrypt/quad9-resolvers.md.minisig
+++ b/dnscrypt/quad9-resolvers.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RUTp2E4t64BrL0erqQUu6bvdb09rNwy1sIl/XDxiapGxvesqBw5Ipznvv6DpgdRuduU5wapUEY4EaQnd3rgOtrP4eDgqauXJcQQ=
-trusted comment: timestamp:1723060100	file:quad9-resolvers.md	hashed
-RT6li2QxEGcaobkkG4MwJU4G+7yrWlTa+lgHwPtrza0huqQteZoObExIMu/Y7bZr0nyr3zQ765iK3sN94PU9AQ==
+RWTp2E4t64BrL8jPAnHnYKvUAoLHo4hqwtGXjHv0o1kCtndmNKNZxtf6rAf11kN4Oabk0lEKtOd0Qn4jLywF/QWHvYL68vmtaQA=
+trusted comment: timestamp:1723206106	file:quad9-resolvers.md
+c7kjA1rThLOgpnlZ5uhnA1m8nvC53rzRNQp8O9N1efAR6JybA8YP3Ur8DWQqtkK6ElNStjOO36jeHxRJZVwsDA==


### PR DESCRIPTION
Sign all md files using legacy algo to keep old versions of dnscrypt-proxy happy. This also fixes reported issues with packaged version of dnscrypt-proxy on certain Linux distros (e.g. Fedora) that show different behavior compared to the original codebase.
